### PR TITLE
feat: scaffold web dashboard and api services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.env
+.env.local
+apps/api/.env
+apps/api/dist
+apps/web/.next
+apps/web/out
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# Dropship
+# Dropship Operations Platform
+
+Monorepo containing the Dropship operations dashboard (Next.js) and backend API (Express + Prisma). The platform centralises supplier imports, product lifecycle management, order tracking, and customer support workflows across major marketplaces.
+
+## Project Structure
+
+```
+./apps
+  ├── api   # Express REST API with Prisma, PostgreSQL, Redis, and Jest tests
+  └── web   # Next.js 13 App Router frontend with Tailwind CSS
+```
+
+Additional documentation lives in [`docs/PRD.md`](docs/PRD.md).
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- npm 8+ (or compatible package manager)
+- PostgreSQL 14+
+- Redis 6+
+
+### Install Dependencies
+
+```bash
+npm install
+```
+
+### Environment Variables
+
+Copy the provided example file and adjust credentials:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+```
+
+Update `DATABASE_URL`, OAuth credentials, and JWT secret as needed. The Next.js app consumes the API via `NEXT_PUBLIC_API_BASE_URL`, which can be set in `apps/web/.env.local`:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:4000/api
+```
+
+### Database Setup
+
+Generate Prisma client and apply migrations:
+
+```bash
+cd apps/api
+npx prisma generate
+npx prisma migrate deploy
+```
+
+### Development Servers
+
+Run API and frontend in parallel from the repository root:
+
+```bash
+# Terminal 1 - API
+cd apps/api
+npm run dev
+
+# Terminal 2 - Web
+cd apps/web
+npm run dev
+```
+
+The frontend is available at `http://localhost:3000` and the API at `http://localhost:4000`.
+
+### Testing
+
+API service tests use Jest with lightweight mocks:
+
+```bash
+cd apps/api
+npm test
+```
+
+Frontend testing can be performed with Testing Library (no example specs included yet):
+
+```bash
+cd apps/web
+npm test
+```
+
+## Deployment Notes
+
+1. **API**
+   - Build the TypeScript project: `npm run build` inside `apps/api`.
+   - Configure environment variables for Postgres, Redis, JWT secret, and OAuth credentials.
+   - Run database migrations before first deploy: `npx prisma migrate deploy`.
+   - Provision logging aggregation; logs are structured JSON via `logger.ts` helpers.
+   - Attach monitoring to the `/healthz` endpoint for uptime probes.
+
+2. **Frontend**
+   - Build with `npm run build` inside `apps/web`.
+   - Set `NEXT_PUBLIC_API_BASE_URL` to the deployed API URL.
+   - Configure hosting (Vercel, Netlify, etc.) with environment variables and Node 18 runtime.
+
+3. **Caching & Rate Limiting**
+   - Redis is required for supplier import pub/sub and caching.
+   - Express rate limiting is enabled globally (120 req/minute by default). Adjust via `apiLimiter`.
+
+4. **Authentication**
+   - The API uses JWT bearer tokens for authenticated calls. Obtain tokens via `/api/auth/login`.
+   - OAuth integrations for Google and GitHub are registered with Passport strategies. Update callback URLs according to hosting provider.
+
+## Monitoring & Observability
+
+- Requests are logged via `morgan` and custom JSON logger helpers.
+- Extend metrics collection by scraping logs or integrating with APM services.
+
+## Contributing
+
+- Follow the structure defined in `docs/PRD.md` when extending UI or API endpoints.
+- Add Jest or Testing Library specs for new critical flows.
+
+## License
+
+MIT

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dropship"
+REDIS_URL="redis://localhost:6379"
+JWT_SECRET="super-secret"
+GITHUB_CLIENT_ID=""
+GITHUB_CLIENT_SECRET=""
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'js'],
+  setupFiles: ['dotenv/config']
+};

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@dropship/api",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "lint": "eslint . --ext .ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.4.1",
+    "axios": "^1.5.1",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.9.0",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.1",
+    "morgan": "^1.10.0",
+    "passport": "^0.6.0",
+    "passport-github2": "^0.1.12",
+    "passport-google-oauth20": "^2.0.0",
+    "redis": "^4.6.7",
+    "zod": "^3.22.2"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.5",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/morgan": "^1.9.4",
+    "@types/node": "^20.4.2",
+    "@types/passport-github2": "^0.1.6",
+    "@types/passport-google-oauth20": "^2.0.12",
+    "@types/supertest": "^2.0.12",
+    "eslint": "^8.48.0",
+    "jest": "^29.6.4",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,215 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  email         String   @unique
+  passwordHash  String?
+  name          String?
+  role          UserRole @default(AGENT)
+  provider      AuthProvider @default(LOCAL)
+  providerId    String?  @unique
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  customers     Customer[]
+  supportTickets SupportTicket[] @relation("TicketAssignee")
+}
+
+enum UserRole {
+  ADMIN
+  MANAGER
+  AGENT
+}
+
+enum AuthProvider {
+  LOCAL
+  GOOGLE
+  GITHUB
+}
+
+model Supplier {
+  id           String          @id @default(cuid())
+  name         String
+  marketplace  Marketplace
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+  imports      SupplierImport[]
+  products     Product[]
+
+  @@unique([name, marketplace], name: "name_marketplace")
+}
+
+enum Marketplace {
+  AMAZON
+  EBAY
+  ALIEXPRESS
+  ONBUY
+}
+
+model SupplierImport {
+  id           String      @id @default(cuid())
+  supplier     Supplier    @relation(fields: [supplierId], references: [id])
+  supplierId   String
+  status       ImportStatus @default(PENDING)
+  payload      Json
+  createdAt    DateTime    @default(now())
+  completedAt  DateTime?
+  draftProducts DraftProduct[]
+}
+
+enum ImportStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+}
+
+model DraftProduct {
+  id            String         @id @default(cuid())
+  title         String
+  cost          Float
+  price         Float
+  status        DraftStatus    @default(REVIEW)
+  import        SupplierImport @relation(fields: [importId], references: [id])
+  importId      String
+  assignedTo    User?          @relation(fields: [assignedToId], references: [id])
+  assignedToId  String?
+  product       Product?
+  createdAt     DateTime       @default(now())
+}
+
+enum DraftStatus {
+  REVIEW
+  APPROVED
+  PUBLISHED
+  ARCHIVED
+}
+
+model Product {
+  id            String      @id @default(cuid())
+  sku           String      @unique
+  title         String
+  description   String?
+  price         Float
+  stock         Int         @default(0)
+  status        ProductStatus @default(DRAFT)
+  draft         DraftProduct?
+  supplier      Supplier?   @relation(fields: [supplierId], references: [id])
+  supplierId    String?
+  orders        OrderItem[]
+  marketplaceListings MarketplaceListing[]
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+}
+
+enum ProductStatus {
+  DRAFT
+  ACTIVE
+  PAUSED
+  RETIRED
+}
+
+model MarketplaceListing {
+  id            String       @id @default(cuid())
+  product       Product      @relation(fields: [productId], references: [id])
+  productId     String
+  marketplace   Marketplace
+  marketplaceSku String
+  status        ListingStatus @default(PENDING)
+  lastSyncedAt  DateTime?
+}
+
+enum ListingStatus {
+  PENDING
+  SYNCED
+  ERROR
+}
+
+model Order {
+  id            String      @id @default(cuid())
+  orderNumber   String      @unique
+  customer      Customer    @relation(fields: [customerId], references: [id])
+  customerId    String
+  channel       Marketplace
+  total         Float
+  fulfillment   FulfillmentStatus @default(PENDING)
+  placedAt      DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  items         OrderItem[]
+  tracking      TrackingEvent[]
+  supportTickets SupportTicket[]
+}
+
+enum FulfillmentStatus {
+  PENDING
+  IN_PROGRESS
+  FULFILLED
+  ISSUE
+}
+
+model OrderItem {
+  id        String   @id @default(cuid())
+  order     Order    @relation(fields: [orderId], references: [id])
+  orderId   String
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+  quantity  Int
+  price     Float
+}
+
+model TrackingEvent {
+  id        String   @id @default(cuid())
+  order     Order    @relation(fields: [orderId], references: [id])
+  orderId   String
+  status    String
+  occurredAt DateTime @default(now())
+  metadata  Json?
+}
+
+model Customer {
+  id            String      @id @default(cuid())
+  name          String
+  email         String      @unique
+  phone         String?
+  lifetimeValue Float        @default(0)
+  owner         User?       @relation(fields: [ownerId], references: [id])
+  ownerId       String?
+  orders        Order[]
+  supportTickets SupportTicket[]
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+}
+
+model SupportTicket {
+  id           String       @id @default(cuid())
+  subject      String
+  status       TicketStatus @default(OPEN)
+  priority     TicketPriority @default(MEDIUM)
+  order        Order?       @relation(fields: [orderId], references: [id])
+  orderId      String?
+  customer     Customer     @relation(fields: [customerId], references: [id])
+  customerId   String
+  assignee     User?        @relation("TicketAssignee", fields: [assigneeId], references: [id])
+  assigneeId   String?
+  notes        Json?
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+}
+
+enum TicketStatus {
+  OPEN
+  WAITING
+  RESOLVED
+}
+
+enum TicketPriority {
+  LOW
+  MEDIUM
+  HIGH
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,0 +1,16 @@
+import 'dotenv/config';
+
+export const env = {
+  port: process.env.PORT ? Number(process.env.PORT) : 4000,
+  databaseUrl: process.env.DATABASE_URL ?? '',
+  redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  jwtSecret: process.env.JWT_SECRET ?? 'changeme',
+  githubClientId: process.env.GITHUB_CLIENT_ID,
+  githubClientSecret: process.env.GITHUB_CLIENT_SECRET,
+  googleClientId: process.env.GOOGLE_CLIENT_ID,
+  googleClientSecret: process.env.GOOGLE_CLIENT_SECRET
+};
+
+if (!env.databaseUrl) {
+  console.warn('DATABASE_URL is not configured. Prisma will fail to connect.');
+}

--- a/apps/api/src/config/logger.ts
+++ b/apps/api/src/config/logger.ts
@@ -1,0 +1,7 @@
+export function logInfo(message: string, meta?: Record<string, unknown>) {
+  console.info(JSON.stringify({ level: 'info', message, ...meta }));
+}
+
+export function logError(message: string, meta?: Record<string, unknown>) {
+  console.error(JSON.stringify({ level: 'error', message, ...meta }));
+}

--- a/apps/api/src/config/redis.ts
+++ b/apps/api/src/config/redis.ts
@@ -1,0 +1,15 @@
+import { createClient } from 'redis';
+import { env } from './env';
+
+export const redisClient = createClient({ url: env.redisUrl });
+
+redisClient.on('error', (err) => {
+  console.error('Redis error', err);
+});
+
+export async function ensureRedis() {
+  if (!redisClient.isOpen) {
+    await redisClient.connect();
+  }
+  return redisClient;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,63 @@
+import express from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import morgan from 'morgan';
+import passport from 'passport';
+import { Strategy as GitHubStrategy } from 'passport-github2';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
+import { env } from './config/env';
+import { apiLimiter } from './middleware/rateLimit';
+import router from './routes';
+import { errorHandler } from './middleware/errorHandler';
+import { logInfo } from './config/logger';
+
+const app = express();
+
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+app.use(morgan('combined'));
+app.use(apiLimiter);
+
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: env.githubClientId ?? 'github-client-id',
+      clientSecret: env.githubClientSecret ?? 'github-secret',
+      callbackURL: '/auth/github/callback'
+    },
+    (_accessToken, _refreshToken, profile, done) => {
+      done(null, profile);
+    }
+  )
+);
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: env.googleClientId ?? 'google-client-id',
+      clientSecret: env.googleClientSecret ?? 'google-secret',
+      callbackURL: '/auth/google/callback'
+    },
+    (_accessToken, _refreshToken, profile, done) => {
+      done(null, profile);
+    }
+  )
+);
+
+app.use(passport.initialize());
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api', router);
+app.use(errorHandler);
+
+if (require.main === module) {
+  app.listen(env.port, () => {
+    logInfo('API listening', { port: env.port });
+  });
+}
+
+export default app;

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = global.prisma ?? new PrismaClient({ log: ['query', 'info', 'warn', 'error'] });
+
+if (process.env.NODE_ENV !== 'production') {
+  global.prisma = prisma;
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { env } from '../config/env';
+
+export interface AuthenticatedRequest extends Request {
+  user?: { id: string; role: string };
+}
+
+export function authenticate(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+  const header = req.headers.authorization;
+  if (!header) {
+    return res.status(401).json({ message: 'Missing authorization header' });
+  }
+
+  const token = header.replace('Bearer ', '');
+  try {
+    const payload = jwt.verify(token, env.jwtSecret) as { sub: string; role: string };
+    req.user = { id: payload.sub, role: payload.role };
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,0 +1,7 @@
+import { NextFunction, Request, Response } from 'express';
+import { logError } from '../config/logger';
+
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+  logError('Unhandled error', { err });
+  res.status(500).json({ message: 'Internal server error' });
+}

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,0 +1,8 @@
+import rateLimit from 'express-rate-limit';
+
+export const apiLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import { authenticateUser, generateToken, registerUser } from '../services/authService';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+router.post('/register', async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    const user = await registerUser(email, password);
+    res.status(201).json(user);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/login', async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    const token = await authenticateUser(email, password);
+    res.json({ token });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/token', async (req, res, next) => {
+  try {
+    const { userId } = req.body;
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    const token = generateToken(user.id, user.role);
+    res.json({ token });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/customers.ts
+++ b/apps/api/src/routes/customers.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth';
+import { getCustomerWithHistory, upsertCustomer } from '../services/customerService';
+
+const router = Router();
+
+const customerSchema = z.object({ id: z.string().optional(), email: z.string().email(), name: z.string(), phone: z.string().optional() });
+
+router.post('/', authenticate, async (req, res, next) => {
+  try {
+    const parsed = customerSchema.parse(req.body);
+    const customer = await upsertCustomer(parsed);
+    res.status(201).json(customer);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:customerId', authenticate, async (req, res, next) => {
+  try {
+    const customer = await getCustomerWithHistory(req.params.customerId);
+    if (!customer) {
+      return res.status(404).json({ message: 'Customer not found' });
+    }
+    res.json(customer);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import auth from './auth';
+import suppliers from './suppliers';
+import products from './products';
+import orders from './orders';
+import customers from './customers';
+import support from './support';
+
+const router = Router();
+
+router.use('/auth', auth);
+router.use('/suppliers', suppliers);
+router.use('/products', products);
+router.use('/orders', orders);
+router.use('/customers', customers);
+router.use('/support', support);
+
+export default router;

--- a/apps/api/src/routes/orders.ts
+++ b/apps/api/src/routes/orders.ts
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth';
+import { FulfillmentStatus, Marketplace } from '@prisma/client';
+import { importMarketplaceOrders, recordOrder, updateFulfillment } from '../services/orderService';
+
+const router = Router();
+
+const orderSchema = z.object({
+  orderNumber: z.string(),
+  customerId: z.string(),
+  channel: z.nativeEnum(Marketplace),
+  total: z.number(),
+  items: z.array(z.object({ productId: z.string(), quantity: z.number(), price: z.number() }))
+});
+
+const fulfillmentSchema = z.object({ status: z.nativeEnum(FulfillmentStatus) });
+
+router.post('/', authenticate, async (req, res, next) => {
+  try {
+    const parsed = orderSchema.parse(req.body);
+    const order = await recordOrder(parsed);
+    res.status(201).json(order);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch('/:orderId/fulfillment', authenticate, async (req, res, next) => {
+  try {
+    const parsed = fulfillmentSchema.parse(req.body);
+    const order = await updateFulfillment(req.params.orderId, parsed.status);
+    res.json(order);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/import/:channel', authenticate, async (req, res, next) => {
+  try {
+    const channel = Marketplace[req.params.channel as keyof typeof Marketplace];
+    if (!channel) {
+      return res.status(400).json({ message: 'Invalid channel' });
+    }
+    const data = await importMarketplaceOrders(channel);
+    res.json({ imported: data });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/products.ts
+++ b/apps/api/src/routes/products.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth';
+import { Marketplace } from '@prisma/client';
+import { publishProductFromDraft, updateInventory } from '../services/productService';
+
+const router = Router();
+
+const publishSchema = z.object({
+  draftId: z.string(),
+  marketplaces: z.array(z.nativeEnum(Marketplace))
+});
+
+const inventorySchema = z.object({ stock: z.number(), price: z.number().optional() });
+
+router.post('/publish', authenticate, async (req, res, next) => {
+  try {
+    const parsed = publishSchema.parse(req.body);
+    const product = await publishProductFromDraft(parsed.draftId, parsed.marketplaces);
+    res.status(201).json(product);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch('/:productId/inventory', authenticate, async (req, res, next) => {
+  try {
+    const parsed = inventorySchema.parse(req.body);
+    const product = await updateInventory(req.params.productId, parsed.stock, parsed.price);
+    res.json(product);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/suppliers.ts
+++ b/apps/api/src/routes/suppliers.ts
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth';
+import { createSupplier, ingestCatalog, completeImport } from '../services/supplierService';
+import { Marketplace, ImportStatus } from '@prisma/client';
+
+const router = Router();
+
+const supplierSchema = z.object({ name: z.string(), marketplace: z.nativeEnum(Marketplace) });
+const ingestSchema = z.object({ supplierId: z.string(), payload: z.any() });
+const completeSchema = z.object({
+  status: z.nativeEnum(ImportStatus),
+  drafts: z.array(z.object({ title: z.string(), cost: z.number(), price: z.number() }))
+});
+
+router.post('/', authenticate, async (req, res, next) => {
+  try {
+    const parsed = supplierSchema.parse(req.body);
+    const supplier = await createSupplier(parsed.name, parsed.marketplace);
+    res.status(201).json(supplier);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/ingest', authenticate, async (req, res, next) => {
+  try {
+    const parsed = ingestSchema.parse(req.body);
+    const job = await ingestCatalog(parsed.supplierId, parsed.payload);
+    res.status(202).json(job);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:importId/complete', authenticate, async (req, res, next) => {
+  try {
+    const parsed = completeSchema.parse(req.body);
+    const importJob = await completeImport(req.params.importId, parsed.status, parsed.drafts);
+    res.json(importJob);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/support.ts
+++ b/apps/api/src/routes/support.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth';
+import { createTicket, updateTicketStatus } from '../services/supportService';
+import { TicketPriority, TicketStatus } from '@prisma/client';
+
+const router = Router();
+
+const ticketSchema = z.object({
+  subject: z.string(),
+  customerId: z.string(),
+  orderId: z.string().optional(),
+  priority: z.nativeEnum(TicketPriority).optional()
+});
+
+const statusSchema = z.object({ status: z.nativeEnum(TicketStatus) });
+
+router.post('/', authenticate, async (req, res, next) => {
+  try {
+    const parsed = ticketSchema.parse(req.body);
+    const ticket = await createTicket(parsed);
+    res.status(201).json(ticket);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch('/:ticketId/status', authenticate, async (req, res, next) => {
+  try {
+    const parsed = statusSchema.parse(req.body);
+    const ticket = await updateTicketStatus(req.params.ticketId, parsed.status);
+    res.json(ticket);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/authService.ts
+++ b/apps/api/src/services/authService.ts
@@ -1,0 +1,31 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { prisma } from '../lib/prisma';
+import { env } from '../config/env';
+import { UserRole } from '@prisma/client';
+
+export async function registerUser(email: string, password: string, role: UserRole = UserRole.AGENT) {
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    throw new Error('User already exists');
+  }
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { email, passwordHash, role } });
+  return user;
+}
+
+export async function authenticateUser(email: string, password: string) {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user || !user.passwordHash) {
+    throw new Error('Invalid credentials');
+  }
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    throw new Error('Invalid credentials');
+  }
+  return generateToken(user.id, user.role);
+}
+
+export function generateToken(userId: string, role: UserRole) {
+  return jwt.sign({ sub: userId, role }, env.jwtSecret, { expiresIn: '8h' });
+}

--- a/apps/api/src/services/customerService.ts
+++ b/apps/api/src/services/customerService.ts
@@ -1,0 +1,33 @@
+import { prisma } from '../lib/prisma';
+import { ensureRedis } from '../config/redis';
+
+export async function upsertCustomer(input: { id?: string; email: string; name: string; phone?: string }) {
+  return prisma.customer.upsert({
+    where: { email: input.email },
+    update: { name: input.name, phone: input.phone },
+    create: { email: input.email, name: input.name, phone: input.phone }
+  });
+}
+
+export async function getCustomerWithHistory(id: string) {
+  const redis = await ensureRedis();
+  const cacheKey = `customer:${id}`;
+  const cached = await redis.get(cacheKey);
+  if (cached) {
+    return JSON.parse(cached);
+  }
+
+  const customer = await prisma.customer.findUnique({
+    where: { id },
+    include: {
+      orders: { include: { items: true, tracking: true } },
+      supportTickets: true
+    }
+  });
+
+  if (customer) {
+    await redis.set(cacheKey, JSON.stringify(customer), { EX: 60 * 5 });
+  }
+
+  return customer;
+}

--- a/apps/api/src/services/integrationService.ts
+++ b/apps/api/src/services/integrationService.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { Marketplace } from '@prisma/client';
+
+const endpoints: Record<Marketplace, string> = {
+  [Marketplace.AMAZON]: 'https://api.amazon.com/products',
+  [Marketplace.EBAY]: 'https://api.ebay.com/inventory_item',
+  [Marketplace.ALIEXPRESS]: 'https://api.aliexpress.com/items',
+  [Marketplace.ONBUY]: 'https://apicenter.onbuy.com/v2/products'
+};
+
+type SyncPayload = {
+  sku: string;
+  title: string;
+  price: number;
+  stock: number;
+  description?: string | null;
+};
+
+export async function syncProduct(marketplace: Marketplace, payload: SyncPayload) {
+  const url = endpoints[marketplace];
+  // In production we would sign requests with marketplace specific auth. Here we simulate a POST.
+  await axios.post(url, payload, { timeout: 5000 });
+  return { success: true };
+}
+
+export async function fetchOrders(marketplace: Marketplace) {
+  const url = `${endpoints[marketplace]}/orders`;
+  const { data } = await axios.get(url, { timeout: 5000 });
+  return data;
+}

--- a/apps/api/src/services/orderService.ts
+++ b/apps/api/src/services/orderService.ts
@@ -1,0 +1,37 @@
+import { FulfillmentStatus, Marketplace } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { fetchOrders } from './integrationService';
+
+export async function recordOrder(input: {
+  orderNumber: string;
+  customerId: string;
+  channel: Marketplace;
+  total: number;
+  items: { productId: string; quantity: number; price: number }[];
+}) {
+  return prisma.order.create({
+    data: {
+      orderNumber: input.orderNumber,
+      customerId: input.customerId,
+      channel: input.channel,
+      total: input.total,
+      items: {
+        create: input.items.map((item) => ({
+          productId: item.productId,
+          quantity: item.quantity,
+          price: item.price
+        }))
+      }
+    },
+    include: { items: true }
+  });
+}
+
+export async function updateFulfillment(orderId: string, status: FulfillmentStatus) {
+  return prisma.order.update({ where: { id: orderId }, data: { fulfillment: status } });
+}
+
+export async function importMarketplaceOrders(channel: Marketplace) {
+  const data = await fetchOrders(channel);
+  return data;
+}

--- a/apps/api/src/services/productService.ts
+++ b/apps/api/src/services/productService.ts
@@ -1,0 +1,59 @@
+import { Marketplace, ProductStatus, ListingStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { syncProduct } from './integrationService';
+
+export async function publishProductFromDraft(draftId: string, marketplaces: Marketplace[]) {
+  const draft = await prisma.draftProduct.findUnique({ where: { id: draftId }, include: { import: true } });
+  if (!draft) {
+    throw new Error('Draft not found');
+  }
+
+  const product = await prisma.product.create({
+    data: {
+      sku: `SKU-${draft.id.slice(-6)}`,
+      title: draft.title,
+      price: draft.price,
+      status: ProductStatus.ACTIVE,
+      draft: { connect: { id: draft.id } },
+      supplier: draft.import.supplierId ? { connect: { id: draft.import.supplierId } } : undefined,
+      marketplaceListings: {
+        create: marketplaces.map((marketplace) => ({
+          marketplace,
+          marketplaceSku: `MKT-${marketplace}-${draft.id.slice(-4)}`,
+          status: ListingStatus.PENDING
+        }))
+      }
+    },
+    include: { marketplaceListings: true }
+  });
+
+  await Promise.all(
+    product.marketplaceListings.map((listing) =>
+      syncProduct(listing.marketplace, {
+        sku: listing.marketplaceSku,
+        title: product.title,
+        price: product.price,
+        stock: product.stock,
+        description: product.description
+      }).catch(async () => {
+        await prisma.marketplaceListing.update({
+          where: { id: listing.id },
+          data: { status: ListingStatus.ERROR }
+        });
+      })
+    )
+  );
+
+  return product;
+}
+
+export async function updateInventory(productId: string, stock: number, price?: number) {
+  const product = await prisma.product.update({
+    where: { id: productId },
+    data: {
+      stock,
+      price: price ?? undefined
+    }
+  });
+  return product;
+}

--- a/apps/api/src/services/supplierService.ts
+++ b/apps/api/src/services/supplierService.ts
@@ -1,0 +1,40 @@
+import { Marketplace, ImportStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { ensureRedis } from '../config/redis';
+
+export async function createSupplier(name: string, marketplace: Marketplace) {
+  return prisma.supplier.upsert({
+    where: { name_marketplace: { name, marketplace } },
+    update: {},
+    create: { name, marketplace }
+  });
+}
+
+export async function ingestCatalog(supplierId: string, payload: unknown) {
+  const job = await prisma.supplierImport.create({
+    data: {
+      supplierId,
+      payload: payload as object,
+      status: ImportStatus.PROCESSING
+    }
+  });
+
+  const redis = await ensureRedis();
+  await redis.publish('supplier:imports', JSON.stringify({ importId: job.id }));
+  return job;
+}
+
+export async function completeImport(importId: string, status: ImportStatus, drafts: { title: string; cost: number; price: number }[]) {
+  const importJob = await prisma.supplierImport.update({
+    where: { id: importId },
+    data: {
+      status,
+      completedAt: new Date(),
+      draftProducts: {
+        create: drafts.map((draft) => ({ title: draft.title, cost: draft.cost, price: draft.price }))
+      }
+    },
+    include: { draftProducts: true }
+  });
+  return importJob;
+}

--- a/apps/api/src/services/supportService.ts
+++ b/apps/api/src/services/supportService.ts
@@ -1,0 +1,22 @@
+import { TicketPriority, TicketStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+
+export async function createTicket(input: {
+  subject: string;
+  customerId: string;
+  orderId?: string;
+  priority?: TicketPriority;
+}) {
+  return prisma.supportTicket.create({
+    data: {
+      subject: input.subject,
+      customerId: input.customerId,
+      orderId: input.orderId,
+      priority: input.priority ?? TicketPriority.MEDIUM
+    }
+  });
+}
+
+export async function updateTicketStatus(id: string, status: TicketStatus) {
+  return prisma.supportTicket.update({ where: { id }, data: { status } });
+}

--- a/apps/api/tests/authService.test.ts
+++ b/apps/api/tests/authService.test.ts
@@ -1,0 +1,13 @@
+import jwt from 'jsonwebtoken';
+import { generateToken } from '../src/services/authService';
+import { UserRole } from '@prisma/client';
+import { env } from '../src/config/env';
+
+describe('authService', () => {
+  it('generates a JWT with expected payload', () => {
+    const token = generateToken('user-1', UserRole.ADMIN);
+    const decoded = jwt.verify(token, env.jwtSecret) as { sub: string; role: string };
+    expect(decoded.sub).toBe('user-1');
+    expect(decoded.role).toBe(UserRole.ADMIN);
+  });
+});

--- a/apps/api/tests/productService.test.ts
+++ b/apps/api/tests/productService.test.ts
@@ -1,0 +1,20 @@
+import { updateInventory } from '../src/services/productService';
+import { prisma } from '../src/lib/prisma';
+
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    product: {
+      update: jest.fn().mockResolvedValue({ id: 'prod-1', stock: 10, price: 20 })
+    }
+  }
+}));
+
+describe('productService', () => {
+  it('updates inventory values', async () => {
+    await updateInventory('prod-1', 10, 20);
+    expect(prisma.product.update).toHaveBeenCalledWith({
+      where: { id: 'prod-1' },
+      data: { stock: 10, price: 20 }
+    });
+  });
+});

--- a/apps/api/tests/supplierService.test.ts
+++ b/apps/api/tests/supplierService.test.ts
@@ -1,0 +1,24 @@
+import { ingestCatalog } from '../src/services/supplierService';
+import { prisma } from '../src/lib/prisma';
+
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    supplierImport: {
+      create: jest.fn().mockResolvedValue({ id: 'import-1' })
+    }
+  }
+}));
+
+const publishMock = jest.fn();
+
+jest.mock('../src/config/redis', () => ({
+  ensureRedis: jest.fn().mockResolvedValue({ publish: publishMock })
+}));
+
+describe('supplierService', () => {
+  it('publishes import job to Redis', async () => {
+    await ingestCatalog('supplier-1', { products: [] });
+    expect(prisma.supplierImport.create).toHaveBeenCalled();
+    expect(publishMock).toHaveBeenCalledWith('supplier:imports', expect.any(String));
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/app/customers/page.tsx
+++ b/apps/web/app/customers/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { customers, orders, tickets } from '../../lib/sample-data';
+import { PageHeader } from '../../components/PageHeader';
+import { useSelection } from '../../components/SelectionContext';
+
+export default function CustomersPage() {
+  const { selectedCustomerId, setSelectedCustomerId, setSelectedOrderId } = useSelection();
+  const selectedCustomer = customers.find((customer) => customer.id === selectedCustomerId) ?? customers[0];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Customers"
+        description="Understand customer health, lifetime value, and open support conversations."
+        action={<button className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white">Export Segment</button>}
+      />
+      <div className="grid gap-6 lg:grid-cols-3">
+        <aside className="space-y-3 lg:col-span-1">
+          {customers.map((customer) => {
+            const isActive = selectedCustomerId ? selectedCustomerId === customer.id : customer.id === selectedCustomer.id;
+            return (
+              <button
+                key={customer.id}
+                className={`w-full rounded-lg border p-4 text-left text-sm transition ${
+                  isActive ? 'border-brand bg-indigo-50 text-brand' : 'border-gray-200 bg-white text-gray-700 hover:border-brand'
+                }`}
+                onClick={() => setSelectedCustomerId(customer.id)}
+              >
+                <div className="font-semibold text-gray-900">{customer.name}</div>
+                <div className="text-xs text-gray-500">{customer.email}</div>
+                <div className="mt-2 text-xs text-gray-500">Lifetime value: ${customer.lifetimeValue.toFixed(2)}</div>
+              </button>
+            );
+          })}
+        </aside>
+        <section className="space-y-4 rounded-lg bg-white p-6 shadow-sm lg:col-span-2">
+          <h2 className="text-lg font-semibold text-gray-900">{selectedCustomer.name}</h2>
+          <dl className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Preferred Channel</dt>
+              <dd className="text-sm text-gray-800">{selectedCustomer.preferredChannel}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Open Tickets</dt>
+              <dd className="text-sm text-gray-800">{selectedCustomer.openTickets.length || 'None'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-gray-500">Recent Orders</dt>
+              <dd className="space-x-2 text-sm text-indigo-600">
+                {selectedCustomer.recentOrders.map((orderNumber) => {
+                  const order = orders.find((o) => o.orderNumber === orderNumber);
+                  return (
+                    <button key={orderNumber} onClick={() => order && setSelectedOrderId(order.id)} className="underline">
+                      {orderNumber}
+                    </button>
+                  );
+                })}
+              </dd>
+            </div>
+          </dl>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Active Support Tickets</h3>
+            <ul className="mt-2 space-y-2 text-sm text-gray-700">
+              {tickets.filter((ticket) => ticket.customerId === selectedCustomer.id).length === 0 && (
+                <li className="rounded border border-dashed border-gray-200 p-4 text-gray-500">No open tickets 🎉</li>
+              )}
+              {tickets
+                .filter((ticket) => ticket.customerId === selectedCustomer.id)
+                .map((ticket) => (
+                  <li key={ticket.id} className="rounded border border-gray-100 p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-900">{ticket.subject}</span>
+                      <span className="text-xs uppercase text-rose-600">{ticket.priority}</span>
+                    </div>
+                    <p className="text-xs text-gray-500">Ticket {ticket.id}</p>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,62 @@
+import { metrics, recentImports, tickets } from '../../lib/sample-data';
+import { MetricCard } from '../../components/MetricCard';
+import { PageHeader } from '../../components/PageHeader';
+import { SectionCard } from '../../components/SectionCard';
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader title="Dashboard" description="Real-time view of operations across marketplaces." />
+      <dl className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.name} metric={metric} />
+        ))}
+      </dl>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <SectionCard title="Recent Supplier Imports">
+          <ul className="space-y-3">
+            {recentImports.map((importJob) => (
+              <li key={importJob.id} className="flex items-center justify-between rounded-md border border-gray-100 p-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{importJob.supplier}</p>
+                  <p className="text-xs text-gray-500">
+                    {importJob.marketplace} • {new Date(importJob.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-medium capitalize ${
+                    importJob.status === 'completed'
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : importJob.status === 'processing'
+                      ? 'bg-indigo-100 text-indigo-700'
+                      : 'bg-rose-100 text-rose-700'
+                  }`}
+                >
+                  {importJob.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </SectionCard>
+        <SectionCard title="Escalated Support Tickets">
+          <ul className="space-y-3">
+            {tickets
+              .filter((ticket) => ticket.priority === 'high')
+              .map((ticket) => (
+                <li key={ticket.id} className="rounded-md border border-gray-100 p-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-gray-900">{ticket.subject}</p>
+                    <span className="text-xs font-medium uppercase text-rose-600">{ticket.priority}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Ticket {ticket.id} • SLA {ticket.slaExpiresIn}
+                    {ticket.orderNumber ? ` • Order ${ticket.orderNumber}` : ''}
+                  </p>
+                </li>
+              ))}
+          </ul>
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/drafts/page.tsx
+++ b/apps/web/app/drafts/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { draftProducts } from '../../lib/sample-data';
+import { PageHeader } from '../../components/PageHeader';
+import { useSelection } from '../../components/SelectionContext';
+
+export default function DraftsPage() {
+  const { selectedDraftId, setSelectedDraftId } = useSelection();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Drafts"
+        description="Review imported products before publishing to marketplaces."
+        action={<button className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white">Publish Selected</button>}
+      />
+      <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {draftProducts.map((draft) => {
+          const isActive = selectedDraftId === draft.id;
+          return (
+            <li
+              key={draft.id}
+              className={`cursor-pointer rounded-lg border p-4 shadow-sm transition ${
+                isActive ? 'border-brand bg-indigo-50' : 'border-gray-200 bg-white hover:border-brand'
+              }`}
+              onClick={() => setSelectedDraftId(isActive ? undefined : draft.id)}
+            >
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="text-base font-semibold text-gray-900">{draft.name}</h3>
+                  <p className="text-xs text-gray-500">{draft.category}</p>
+                </div>
+                <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">{draft.source}</span>
+              </div>
+              <dl className="mt-4 space-y-1 text-sm text-gray-600">
+                <div className="flex justify-between">
+                  <dt>Profitability</dt>
+                  <dd>{draft.profitability}%</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt>Manager</dt>
+                  <dd>{draft.manager}</dd>
+                </div>
+              </dl>
+            </li>
+          );
+        })}
+      </ul>
+      {selectedDraftId && (
+        <div className="rounded-lg border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900">
+          Draft {selectedDraftId} selected. Related product and ticket information is highlighted in other views.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,26 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Sidebar } from '../components/Sidebar';
+import { SelectionProvider } from '../components/SelectionContext';
+
+export const metadata: Metadata = {
+  title: 'Dropship Operations Platform',
+  description: 'Operate supplier imports, product lifecycle, orders, and support in one workspace.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <SelectionProvider>
+          <div className="flex h-screen overflow-hidden">
+            <Sidebar />
+            <main className="flex-1 overflow-y-auto p-8">
+              <div className="mx-auto max-w-7xl space-y-8">{children}</div>
+            </main>
+          </div>
+        </SelectionProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/orders/page.tsx
+++ b/apps/web/app/orders/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { DataTable } from '../../components/DataTable';
+import { PageHeader } from '../../components/PageHeader';
+import { orders } from '../../lib/sample-data';
+import { useSelection } from '../../components/SelectionContext';
+
+export default function OrdersPage() {
+  const { selectedOrderId, setSelectedOrderId, setSelectedCustomerId } = useSelection();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Orders"
+        description="Track fulfillment progress and supplier confirmations."
+        action={<button className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white">Bulk Update</button>}
+      />
+      <DataTable
+        data={orders}
+        rowClassName={(order) => (selectedOrderId === order.id ? 'bg-amber-50' : '')}
+        columns={[
+          {
+            header: 'Order',
+            accessor: (order) => (
+              <button
+                className={`text-left font-medium ${selectedOrderId === order.id ? 'text-brand' : 'text-gray-900'}`}
+                onClick={() => setSelectedOrderId(selectedOrderId === order.id ? undefined : order.id)}
+              >
+                {order.orderNumber}
+              </button>
+            )
+          },
+          {
+            header: 'Customer',
+            accessor: (order) => (
+              <button
+                className="text-left text-sm text-indigo-600 hover:underline"
+                onClick={() => setSelectedCustomerId(order.customerId)}
+              >
+                {order.customerName}
+              </button>
+            )
+          },
+          { header: 'Channel', accessor: (order) => order.channel },
+          { header: 'Total', accessor: (order) => `$${order.total.toFixed(2)}` },
+          {
+            header: 'Fulfillment',
+            accessor: (order) => (
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${
+                  order.fulfillment === 'fulfilled'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : order.fulfillment === 'in_progress'
+                    ? 'bg-amber-100 text-amber-700'
+                    : order.fulfillment === 'issue'
+                    ? 'bg-rose-100 text-rose-700'
+                    : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                {order.fulfillment}
+              </span>
+            )
+          },
+          {
+            header: 'Tracking',
+            accessor: (order) => order.tracking ?? '—'
+          }
+        ]}
+        emptyState={<span>No orders available.</span>}
+      />
+      {selectedOrderId && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          Order {selectedOrderId} selected. Linked customer and support tickets are highlighted elsewhere.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/apps/web/app/products/page.tsx
+++ b/apps/web/app/products/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { DataTable } from '../../components/DataTable';
+import { PageHeader } from '../../components/PageHeader';
+import { products } from '../../lib/sample-data';
+import { useSelection } from '../../components/SelectionContext';
+
+export default function ProductsPage() {
+  const { selectedProductId, setSelectedProductId } = useSelection();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Products"
+        description="Monitor catalog performance and marketplace sync status."
+        action={<button className="rounded-md border border-brand px-4 py-2 text-sm font-medium text-brand">Sync to Channels</button>}
+      />
+      <DataTable
+        data={products}
+        rowClassName={(product) => (selectedProductId === product.id ? 'bg-indigo-50/70' : '')}
+        columns={[
+          {
+            header: 'Product',
+            accessor: (product) => (
+              <button
+                className={`text-left font-medium ${selectedProductId === product.id ? 'text-brand' : 'text-gray-900'}`}
+                onClick={() => setSelectedProductId(selectedProductId === product.id ? undefined : product.id)}
+              >
+                {product.title}
+              </button>
+            )
+          },
+          { header: 'SKU', accessor: (product) => product.sku },
+          { header: 'Stock', accessor: (product) => product.stock },
+          {
+            header: 'Price',
+            accessor: (product) => `$${product.price.toFixed(2)}`
+          },
+          {
+            header: 'Channels',
+            accessor: (product) => (
+              <div className="flex flex-wrap gap-1">
+                {product.channels.map((channel) => (
+                  <span key={channel} className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                    {channel}
+                  </span>
+                ))}
+              </div>
+            )
+          },
+          {
+            header: 'Sync State',
+            accessor: (product) => (
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  product.syncState === 'synced'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : product.syncState === 'pending'
+                    ? 'bg-amber-100 text-amber-700'
+                    : 'bg-rose-100 text-rose-700'
+                }`}
+              >
+                {product.syncState}
+              </span>
+            )
+          }
+        ]}
+        emptyState={<span>No products available.</span>}
+      />
+      {selectedProductId && (
+        <div className="rounded-lg border border-brand bg-white p-4 text-sm text-gray-700 shadow-sm">
+          Product {selectedProductId} selected. Draft and support modules now highlight related information.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { PageHeader } from '../../components/PageHeader';
+import { tickets, customers, orders } from '../../lib/sample-data';
+import { useSelection } from '../../components/SelectionContext';
+
+export default function SupportPage() {
+  const { setSelectedCustomerId, setSelectedOrderId } = useSelection();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Customer Support"
+        description="Manage escalations and keep response times within SLA."
+        action={<button className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white">New Response</button>}
+      />
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {tickets.map((ticket) => {
+          const customer = customers.find((c) => c.id === ticket.customerId);
+          const order = ticket.orderNumber ? orders.find((o) => o.orderNumber === ticket.orderNumber) : undefined;
+          return (
+            <article key={ticket.id} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <header className="flex items-start justify-between">
+                <h3 className="text-base font-semibold text-gray-900">{ticket.subject}</h3>
+                <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-semibold uppercase text-rose-600">
+                  {ticket.priority}
+                </span>
+              </header>
+              <dl className="mt-3 space-y-2 text-sm text-gray-600">
+                <div className="flex justify-between">
+                  <dt>Status</dt>
+                  <dd className="capitalize">{ticket.status}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt>SLA</dt>
+                  <dd>{ticket.slaExpiresIn}</dd>
+                </div>
+                {customer && (
+                  <div className="flex justify-between">
+                    <dt>Customer</dt>
+                    <dd>
+                      <button className="text-indigo-600 underline" onClick={() => setSelectedCustomerId(customer.id)}>
+                        {customer.name}
+                      </button>
+                    </dd>
+                  </div>
+                )}
+                {order && (
+                  <div className="flex justify-between">
+                    <dt>Order</dt>
+                    <dd>
+                      <button className="text-indigo-600 underline" onClick={() => setSelectedOrderId(order.id)}>
+                        {order.orderNumber}
+                      </button>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+              <footer className="mt-4 text-xs text-gray-500">Linked issues update relevant modules instantly.</footer>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/DataTable.tsx
+++ b/apps/web/components/DataTable.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+
+type Column<T> = {
+  header: string;
+  accessor: (row: T) => ReactNode;
+  className?: string;
+};
+
+type DataTableProps<T> = {
+  data: T[];
+  columns: Column<T>[];
+  emptyState?: ReactNode;
+  rowClassName?: (row: T) => string;
+};
+
+export function DataTable<T>({ data, columns, emptyState, rowClassName }: DataTableProps<T>) {
+  if (data.length === 0) {
+    return <div className="rounded-lg border border-dashed border-gray-200 p-8 text-center text-sm text-gray-500">{emptyState}</div>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+          <tr>
+            {columns.map((column) => (
+              <th key={column.header} scope="col" className={`px-4 py-3 ${column.className ?? ''}`}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white text-sm text-gray-700">
+          {data.map((row, index) => (
+            <tr key={index} className={`hover:bg-gray-50 ${rowClassName ? rowClassName(row) : ''}`}>
+              {columns.map((column) => (
+                <td key={column.header} className={`px-4 py-3 ${column.className ?? ''}`}>
+                  {column.accessor(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/MetricCard.tsx
+++ b/apps/web/components/MetricCard.tsx
@@ -1,0 +1,17 @@
+import { Metric } from '../lib/sample-data';
+
+export function MetricCard({ metric }: { metric: Metric }) {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <dt className="text-sm font-medium text-gray-500">{metric.name}</dt>
+      <dd className="mt-2 flex items-baseline gap-2">
+        <span className="text-3xl font-semibold text-gray-900">{metric.value}</span>
+        {metric.delta && (
+          <span className={`text-sm font-medium ${metric.positive ? 'text-emerald-600' : 'text-rose-500'}`}>
+            {metric.delta}
+          </span>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/components/PageHeader.tsx
+++ b/apps/web/components/PageHeader.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export function PageHeader({ title, description, action }: { title: string; description?: string; action?: ReactNode }) {
+  return (
+    <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        {description && <p className="mt-1 text-sm text-gray-600">{description}</p>}
+      </div>
+      {action}
+    </header>
+  );
+}

--- a/apps/web/components/SectionCard.tsx
+++ b/apps/web/components/SectionCard.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export function SectionCard({ title, children, action }: { title: string; children: ReactNode; action?: ReactNode }) {
+  return (
+    <section className="rounded-lg bg-white p-6 shadow-sm">
+      <header className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        {action}
+      </header>
+      <div className="space-y-4 text-sm text-gray-600">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/components/SelectionContext.tsx
+++ b/apps/web/components/SelectionContext.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+type SelectionState = {
+  selectedDraftId?: string;
+  selectedProductId?: string;
+  selectedCustomerId?: string;
+  selectedOrderId?: string;
+  setSelectedDraftId: (id?: string) => void;
+  setSelectedProductId: (id?: string) => void;
+  setSelectedCustomerId: (id?: string) => void;
+  setSelectedOrderId: (id?: string) => void;
+};
+
+const SelectionContext = createContext<SelectionState | undefined>(undefined);
+
+export function SelectionProvider({ children }: { children: ReactNode }) {
+  const [selectedDraftId, setSelectedDraftId] = useState<string>();
+  const [selectedProductId, setSelectedProductId] = useState<string>();
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string>();
+  const [selectedOrderId, setSelectedOrderId] = useState<string>();
+
+  const value = useMemo(
+    () => ({
+      selectedDraftId,
+      selectedProductId,
+      selectedCustomerId,
+      selectedOrderId,
+      setSelectedDraftId,
+      setSelectedProductId,
+      setSelectedCustomerId,
+      setSelectedOrderId
+    }),
+    [selectedDraftId, selectedProductId, selectedCustomerId, selectedOrderId]
+  );
+
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>;
+}
+
+export function useSelection() {
+  const context = useContext(SelectionContext);
+  if (!context) {
+    throw new Error('useSelection must be used inside SelectionProvider');
+  }
+  return context;
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { navigation } from '../lib/navigation';
+import { resolveIcon, IconName } from './icons';
+import classNames from 'classnames';
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="flex h-full w-64 flex-col border-r border-gray-200 bg-white">
+      <div className="px-6 py-5 text-lg font-semibold tracking-tight text-brand">Dropship Ops</div>
+      <nav className="flex-1 space-y-1 px-3">
+        {navigation.map((item) => {
+          const Icon = resolveIcon(item.icon as IconName);
+          const active = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={classNames(
+                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                active
+                  ? 'bg-brand text-white shadow'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+              )}
+            >
+              <Icon className="h-5 w-5" />
+              <span>{item.name}</span>
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="border-t border-gray-100 p-4 text-xs text-gray-500">
+        Connected marketplaces synced hourly.
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/icons.tsx
+++ b/apps/web/components/icons.tsx
@@ -1,0 +1,30 @@
+import {
+  ChartPieIcon,
+  CubeIcon,
+  DocumentDuplicateIcon,
+  LifebuoyIcon,
+  TruckIcon,
+  UserGroupIcon
+} from '@heroicons/react/24/outline';
+import { ComponentType, SVGProps } from 'react';
+
+export type IconName =
+  | 'ChartPieIcon'
+  | 'CubeIcon'
+  | 'DocumentDuplicateIcon'
+  | 'LifebuoyIcon'
+  | 'TruckIcon'
+  | 'UserGroupIcon';
+
+const mapping: Record<IconName, ComponentType<SVGProps<SVGSVGElement>>> = {
+  ChartPieIcon,
+  CubeIcon,
+  DocumentDuplicateIcon,
+  LifebuoyIcon,
+  TruckIcon,
+  UserGroupIcon
+};
+
+export function resolveIcon(name: IconName) {
+  return mapping[name];
+}

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -1,0 +1,14 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  moduleDirectories: ['node_modules', '<rootDir>/'],
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^.+\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  }
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -1,0 +1,14 @@
+export type NavigationItem = {
+  name: string;
+  href: string;
+  icon: string;
+};
+
+export const navigation: NavigationItem[] = [
+  { name: 'Dashboard', href: '/dashboard', icon: 'ChartPieIcon' },
+  { name: 'Drafts', href: '/drafts', icon: 'DocumentDuplicateIcon' },
+  { name: 'Products', href: '/products', icon: 'CubeIcon' },
+  { name: 'Orders', href: '/orders', icon: 'TruckIcon' },
+  { name: 'Customers', href: '/customers', icon: 'UserGroupIcon' },
+  { name: 'Customer Support', href: '/support', icon: 'LifebuoyIcon' }
+];

--- a/apps/web/lib/sample-data.ts
+++ b/apps/web/lib/sample-data.ts
@@ -1,0 +1,108 @@
+export type Metric = {
+  name: string;
+  value: string;
+  delta?: string;
+  positive?: boolean;
+};
+
+export const metrics: Metric[] = [
+  { name: 'Gross Merchandise Value', value: '$420K', delta: '+12.4%', positive: true },
+  { name: 'Orders', value: '3,421', delta: '+4.1%', positive: true },
+  { name: 'Fulfillment Rate', value: '96.7%', delta: '-1.3%', positive: false },
+  { name: 'Support SLA', value: '1.8h', delta: '+0.3h', positive: false }
+];
+
+export type SupplierImport = {
+  id: string;
+  supplier: string;
+  marketplace: string;
+  createdAt: string;
+  status: 'processing' | 'completed' | 'failed';
+};
+
+export const recentImports: SupplierImport[] = [
+  { id: 'imp_101', supplier: 'Shenzhen Gadgets', marketplace: 'AliExpress', createdAt: '2023-11-02', status: 'completed' },
+  { id: 'imp_102', supplier: 'UK Direct', marketplace: 'OnBuy', createdAt: '2023-11-01', status: 'processing' },
+  { id: 'imp_103', supplier: 'Prime Partners', marketplace: 'Amazon', createdAt: '2023-10-31', status: 'failed' }
+];
+
+export type DraftProduct = {
+  id: string;
+  name: string;
+  category: string;
+  profitability: number;
+  source: string;
+  manager: string;
+};
+
+export const draftProducts: DraftProduct[] = [
+  { id: 'draft-1', name: 'Wireless Earbuds', category: 'Electronics', profitability: 68, source: 'AliExpress', manager: 'Casey' },
+  { id: 'draft-2', name: 'Ergonomic Chair', category: 'Home Office', profitability: 55, source: 'Amazon', manager: 'Jordan' },
+  { id: 'draft-3', name: 'LED Desk Lamp', category: 'Lighting', profitability: 72, source: 'eBay', manager: 'Casey' }
+];
+
+export type Product = {
+  id: string;
+  title: string;
+  sku: string;
+  stock: number;
+  price: number;
+  status: 'active' | 'out_of_stock' | 'paused';
+  channels: string[];
+  syncState: 'synced' | 'pending' | 'error';
+};
+
+export const products: Product[] = [
+  { id: 'prod-1', title: 'Standing Desk', sku: 'DESK-001', stock: 54, price: 399.0, status: 'active', channels: ['Amazon', 'eBay'], syncState: 'synced' },
+  { id: 'prod-2', title: 'Noise Cancelling Headphones', sku: 'AUD-100', stock: 12, price: 149.99, status: 'active', channels: ['Amazon', 'OnBuy'], syncState: 'pending' },
+  { id: 'prod-3', title: 'Smartwatch Series 5', sku: 'WATCH-5', stock: 0, price: 199.99, status: 'out_of_stock', channels: ['AliExpress'], syncState: 'error' }
+];
+
+export type Order = {
+  id: string;
+  orderNumber: string;
+  customerName: string;
+  customerId: string;
+  channel: string;
+  total: number;
+  fulfillment: 'pending' | 'in_progress' | 'fulfilled' | 'issue';
+  tracking?: string;
+};
+
+export const orders: Order[] = [
+  { id: 'ord-1', orderNumber: 'A-10092', customerName: 'Logan Reeves', customerId: 'cust-1', channel: 'Amazon', total: 249.99, fulfillment: 'fulfilled', tracking: '1Z234' },
+  { id: 'ord-2', orderNumber: 'E-78421', customerName: 'Morgan Lee', customerId: 'cust-2', channel: 'eBay', total: 89.5, fulfillment: 'in_progress', tracking: '9400' },
+  { id: 'ord-3', orderNumber: 'O-66750', customerName: 'Alex Murphy', customerId: 'cust-3', channel: 'OnBuy', total: 39.99, fulfillment: 'issue' }
+];
+
+export type Customer = {
+  id: string;
+  name: string;
+  lifetimeValue: number;
+  email: string;
+  recentOrders: string[];
+  preferredChannel: string;
+  openTickets: string[];
+};
+
+export const customers: Customer[] = [
+  { id: 'cust-1', name: 'Logan Reeves', lifetimeValue: 1520.45, email: 'logan@example.com', recentOrders: ['A-10092', 'A-10011'], preferredChannel: 'Email', openTickets: [] },
+  { id: 'cust-2', name: 'Morgan Lee', lifetimeValue: 890.0, email: 'morgan@example.com', recentOrders: ['E-78421'], preferredChannel: 'Chat', openTickets: ['SUP-301'] },
+  { id: 'cust-3', name: 'Alex Murphy', lifetimeValue: 430.76, email: 'alex@example.com', recentOrders: ['O-66750'], preferredChannel: 'Phone', openTickets: ['SUP-302', 'SUP-305'] }
+];
+
+export type SupportTicket = {
+  id: string;
+  subject: string;
+  priority: 'low' | 'medium' | 'high';
+  slaExpiresIn: string;
+  orderNumber?: string;
+  customerId: string;
+  status: 'open' | 'waiting' | 'resolved';
+};
+
+export const tickets: SupportTicket[] = [
+  { id: 'SUP-301', subject: 'Order delayed shipment', priority: 'high', slaExpiresIn: '0h 45m', orderNumber: 'E-78421', customerId: 'cust-2', status: 'open' },
+  { id: 'SUP-302', subject: 'Received damaged item', priority: 'high', slaExpiresIn: '1h 20m', orderNumber: 'O-66750', customerId: 'cust-3', status: 'waiting' },
+  { id: 'SUP-305', subject: 'Requesting invoice', priority: 'low', slaExpiresIn: '6h 10m', customerId: 'cust-3', status: 'open' }
+];

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@dropship/web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.0.18",
+    "autoprefixer": "^10.4.16",
+    "classnames": "^2.3.2",
+    "next": "13.5.6",
+    "postcss": "^8.4.31",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "^2.2.4",
+    "tailwindcss": "^3.3.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.1",
+    "@types/jest": "^29.5.5",
+    "@types/node": "^20.4.2",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.6.4",
+    "jest-environment-jsdom": "^29.6.4",
+    "typescript": "^5.2.2"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#1f2937',
+          accent: '#6366f1'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["jest", "node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,53 @@
+# Product Requirements Document: Dropship Operations Platform
+
+## Overview
+The Dropship Operations Platform streamlines supplier imports, product lifecycle management, order tracking, and customer support across major marketplaces. The application consists of a Next.js dashboard for operations teams and a Node.js API orchestrating integrations with eBay, Amazon, AliExpress, and OnBuy.
+
+## User Roles
+- **Admin**: Full access to all modules, settings, and integrations.
+- **Operations Manager**: Manages suppliers, products, and orders. Can view metrics and update statuses.
+- **Support Agent**: Handles customer communications and support tickets.
+
+## Modules
+### Dashboard
+- Display high-level metrics (GMV, total orders, fulfillment rate, support SLA).
+- Show recent supplier imports and outstanding support tickets.
+
+### Drafts
+- List drafted products awaiting publication. Provide actions to publish to marketplaces or archive.
+- Surface import source, profitability score, and assigned manager.
+
+### Products
+- Searchable table of all live products with status, stock, channel coverage, and pricing.
+- Support quick edits (price/stock) and display marketplace sync status.
+
+### Orders
+- Table of recent orders with fulfillment progress, tracking data, and supplier confirmations.
+- Support mass status updates and issue flagging.
+
+### Customers
+- Provide customer overview with lifetime value, recent orders, and contact preferences.
+- Allow linking to open support tickets and order history.
+
+### Customer Support
+- Display ticket queue with priority, SLA timers, and linked orders/customers.
+- Enable quick responses and escalation to operations when product or order action required.
+
+## Cross-Module Interactions
+- Selecting a product highlights related draft/import info and outstanding support tickets.
+- Opening a customer profile reveals orders and active tickets.
+- Order rows link to associated customers and fulfillment actions.
+
+## API Requirements
+- Ingest supplier catalogs and create drafts.
+- Manage product lifecycle (draft, published, retired).
+- Track order status, shipment updates, and issues.
+- Store customer profiles, order history, and support tickets.
+- Integrate with eBay, Amazon, AliExpress, and OnBuy for product sync and order import.
+
+## Technical Requirements
+- Frontend: Next.js 13+ with App Router, TypeScript, Tailwind CSS, component-driven architecture.
+- Backend: Node.js (Express + Prisma) with PostgreSQL, Redis caching, JWT auth, optional OAuth providers.
+- Testing: Component tests for critical UI, API tests for lifecycle operations.
+- Observability: Structured logging, request metrics, and health checks.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dropship",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/web",
+    "apps/api"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "dev": "npm run dev --workspaces",
+    "lint": "npm run lint --workspaces",
+    "test": "npm run test --workspaces"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 13 dashboard with sidebar navigation, metric cards, and module pages for drafts, products, orders, customers, and support flows
- add Express API with Prisma models, marketplace integration stubs, Redis caching, JWT/OAuth auth, rate limiting, and logging
- document setup plus add Jest tests for auth, supplier ingest, and inventory updates

## Testing
- not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0f56eeeb88322a00889d3ee58c22e